### PR TITLE
feat: Redesign homepage and update main navigation

### DIFF
--- a/creator-flow/app/page.tsx
+++ b/creator-flow/app/page.tsx
@@ -1,13 +1,54 @@
+'use client'; // Keep if any client-side interactions are planned, not strictly needed for this static content
+
+import Link from 'next/link'; // For the 'Get Started' button
+
 export default function HomePage() {
   return (
-    <section className="text-center py-12">
-      <h2 className="text-4xl font-bold mb-4">Welcome to CreatorFlow!</h2>
-      <p className="text-lg text-gray-700 mb-8">
-        The ultimate platform to streamline your content creation workflow.
-      </p>
-      <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-        Get Started
-      </button>
-    </section>
+    // Main container for the page, aiming for full viewport height if content is short
+    // Using a purple gradient background as preferred
+    <div className="min-h-[calc(100vh-var(--header-height,80px))] flex flex-col justify-center items-center text-white bg-gradient-to-br from-purple-600 via-purple-700 to-indigo-800 px-4 sm:px-6 lg:px-8">
+      {/* Adjust min-h if header height is different or handle dynamically.
+          Assuming header is roughly 80px. Or remove if full screen bg isn't desired under nav.
+          For a simpler approach that fills screen below nav:
+          <div className="flex-grow flex flex-col justify-center items-center text-white bg-gradient-to-br from-purple-600 via-purple-700 to-indigo-800 px-4 sm:px-6 lg:px-8">
+          This assumes Layout.tsx's main tag handles the flex-grow properly.
+          Let's use a simpler approach by not calculating header height here, assuming the main layout handles it.
+      */}
+
+      <div className="flex-grow flex flex-col justify-center items-center text-center py-12"> {/* Centering content */}
+        <div className="max-w-3xl mx-auto"> {/* Constrain width for readability */}
+          {/* Headline */}
+          <h1 className="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-6 leading-tight">
+            Meet Your All-in-One Creator Platform
+          </h1>
+
+          {/* Subtext */}
+          <p className="text-lg sm:text-xl md:text-2xl text-purple-200 mb-10">
+            Launch your courses, digital products, and services all in one place.
+          </p>
+
+          {/* Call to Action Button */}
+          <Link
+            href="/auth/signin"
+            className="bg-white text-purple-700 font-bold py-3 px-8 sm:py-4 sm:px-10 rounded-lg text-lg sm:text-xl hover:bg-purple-100 transition duration-300 ease-in-out shadow-lg transform hover:scale-105"
+          >
+            Get Started
+          </Link>
+        </div>
+
+        {/* Image Placeholder Section */}
+        <div className="mt-16 w-full max-w-2xl">
+          <div className="bg-purple-500/30 backdrop-blur-md p-8 rounded-xl shadow-2xl border border-purple-400/50">
+            <p className="text-xl text-center text-purple-200">
+              App Preview Mockup / Dashboard UI Placeholder
+            </p>
+            {/* You could add a simple SVG or more detailed placeholder structure here */}
+            <div className="mt-4 h-64 bg-purple-400/40 rounded-lg flex items-center justify-center">
+              <svg className="w-16 h-16 text-purple-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/creator-flow/components/Layout.tsx
+++ b/creator-flow/components/Layout.tsx
@@ -1,8 +1,8 @@
-'use client'; // Required because we are using hooks like useAuth
+'use client';
 
 import React from 'react';
-import Link from 'next/link'; // Import Link for navigation
-import { useAuth } from './AuthContext'; // Assuming AuthContext is in the same directory or ./AuthContext
+import Link from 'next/link';
+import { useAuth } from './AuthContext';
 
 type LayoutProps = {
   children: React.ReactNode;
@@ -13,32 +13,39 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="bg-gray-800 text-white p-4">
+      <header className="bg-gray-800 text-white p-4"> {/* Retain existing header style or update as needed */}
         <nav className="container mx-auto flex justify-between items-center">
-          <Link href="/" className="text-xl font-bold"> {/* Make title a link to home */}
+          {/* Logo/Site Title on the far left */}
+          <Link href="/" className="text-xl font-bold">
             CreatorFlow
           </Link>
-          <div>
+
+          {/* Navigation links on the far right */}
+          <div className="flex items-center space-x-4">
             {loading ? (
-              <p>Loading...</p>
+              <p className="text-sm">Loading...</p> // Adjusted loading text style
             ) : user ? (
               <>
-                <span className="mr-4">Welcome, {user.email}</span>
+                <span className="text-sm hidden sm:inline">Welcome, {user.email}</span> {/* Hide on small screens if too crowded */}
                 <button
                   onClick={async () => {
                     await signOut();
-                    // Router push or refresh might be needed if Next.js cache doesn't update UI
-                    // For now, onAuthStateChange in AuthContext should handle UI update
+                    // Consider router.push('/') or similar if staying on a protected page after signout causes issues
                   }}
-                  className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
+                  className="bg-red-500 hover:bg-red-600 text-white px-3 py-2 rounded-md text-sm font-medium"
                 >
                   Sign Out
                 </button>
               </>
             ) : (
-              <Link href="/auth/signin" className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-                Sign In
-              </Link>
+              <>
+                <Link href="/auth/signin" className="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">
+                  Login
+                </Link>
+                <Link href="/auth/signin" className="bg-purple-600 hover:bg-purple-700 text-white px-3 py-2 rounded-md text-sm font-medium">
+                  Sign Up
+                </Link>
+              </>
             )}
           </div>
         </nav>
@@ -46,7 +53,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       <main className="flex-grow container mx-auto p-4">
         {children}
       </main>
-      <footer className="bg-gray-200 text-center p-4">
+      <footer className="bg-gray-200 text-center p-4 mt-auto"> {/* Ensure footer is at the bottom */}
         <p>&copy; {new Date().getFullYear()} CreatorFlow. All rights reserved.</p>
       </footer>
     </div>


### PR DESCRIPTION
Implements a new homepage design inspired by modern creator platforms like Stan.store, and updates the main layout's navigation bar.

Homepage (`app/page.tsx`):
- Features a vibrant purple gradient background.
- Includes a large, welcoming headline: "Meet Your All-in-One Creator Platform."
- Displays supporting subtext: "Launch your courses, digital products, and services all in one place."
- Adds a prominent "Get Started" call-to-action button linking to `/auth/signin`.
- Includes a styled placeholder for an image or app UI mockup.
- Uses TailwindCSS for a modern, responsive design.

Main Navigation (`components/Layout.tsx`):
- Site logo ("CreatorFlow") is positioned on the far left.
- For unauthenticated users: "Login" and "Sign Up" buttons are displayed on the far right (both linking to `/auth/signin`).
- For authenticated users: Your email and a "Sign Out" button are displayed on the far right.
- Styling of navigation elements has been updated for consistency.